### PR TITLE
refactor: update to 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nolana"
 version = "1.0.0"
-edition = "2021"
+edition = "2024"
 authors = ["arexon <arexonreal@gmail.com>"]
 categories = ["parser-implementations", "compilers"]
 description = "An extremely fast parser Molang parser."

--- a/benches/codegen.rs
+++ b/benches/codegen.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
-use criterion::{criterion_group, criterion_main, Criterion};
-use nolana::{ast::Program, Codegen, Parser};
+use criterion::{Criterion, criterion_group, criterion_main};
+use nolana::{Codegen, Parser, ast::Program};
 
 fn codegen(program: &Program) {
     let _ = Codegen::default().build(program);

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use nolana::Parser;
 
 fn parse(source: &str) {

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -1,8 +1,9 @@
 use std::fs;
 
 use nolana::{
+    Codegen, CodegenOptions,
     semantic::SemanticChecker,
-    Codegen, CodegenOptions, {ParseResult, Parser},
+    {ParseResult, Parser},
 };
 
 fn main() {

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use nolana::{
     ast::{CallExpression, CallKind, Program},
-    traverse::{traverse, Traverse},
+    traverse::{Traverse, traverse},
     {ParseResult, Parser},
 };
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -184,11 +184,7 @@ impl From<BooleanLiteral> for Expression<'_> {
 impl BooleanLiteral {
     /// Returns `"true"` or `"false"` depending on this boolean's value.
     pub fn as_str(&self) -> &'static str {
-        if self.value {
-            "true"
-        } else {
-            "false"
-        }
+        if self.value { "true" } else { "false" }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ use logos::{Lexer, Logos};
 
 use crate::{
     ast::*,
-    diagnostic::{errors, Diagnostic, Result},
+    diagnostic::{Diagnostic, Result, errors},
     span::Span,
     token::{Kind, Token},
 };
@@ -200,7 +200,7 @@ impl<'a> Parser<'a> {
             v if v.is_resource() => self.parse_resource_expression()?,
             Kind::Array => self.parse_array_access_expression()?,
             Kind::Loop | Kind::ForEach => {
-                return Err(errors::loop_in_expression(self.end_span_single(span)))
+                return Err(errors::loop_in_expression(self.end_span_single(span)));
             }
             Kind::This => self.parse_this_expression()?,
             Kind::UnterminatedString => {

--- a/src/semantic.rs
+++ b/src/semantic.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::*,
-    diagnostic::{errors, Diagnostic},
-    traverse::{traverse, Traverse},
+    diagnostic::{Diagnostic, errors},
+    traverse::{Traverse, traverse},
 };
 
 /// Traverses an AST and checks the Molang program for any semantic errors.

--- a/tests/semantics.rs
+++ b/tests/semantics.rs
@@ -1,5 +1,5 @@
 use insta::assert_snapshot;
-use nolana::{semantic::SemanticChecker, Parser};
+use nolana::{Parser, semantic::SemanticChecker};
 
 fn semantics(source: &str) -> String {
     let mut result = Parser::new(source).parse();


### PR DESCRIPTION
Resolves #38. `gen()` method had to be renamed as it conflicts with a reserved name for the upcoming [generators](https://dev-doc.rust-lang.org/beta/unstable-book/language-features/generators.html) feature in Rust. Some files were also formatted as `rustfmt` introduced some minor changes.