### PR TITLE
refactor(ast): rename `Identifier` and use `Cow`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{span::Span, token::Kind};
 
 /// Represents the root of a Molang expression AST, containing all the top-level
@@ -207,7 +209,7 @@ impl<'a> From<StringLiteral<'a>> for Expression<'a> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Identifier<'a> {
     pub span: Span,
-    pub name: &'a str,
+    pub name: Cow<'a, str>,
 }
 
 /// <https://bedrock.dev/docs/stable/Molang#Variables>

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -205,7 +205,7 @@ impl<'a> From<StringLiteral<'a>> for Expression<'a> {
 
 /// `foo` in `v.foo.bar`
 #[derive(Debug, Clone, PartialEq)]
-pub struct IdentifierReference<'a> {
+pub struct Identifier<'a> {
     pub span: Span,
     pub name: &'a str,
 }
@@ -268,9 +268,9 @@ impl From<Kind> for VariableLifetime {
 #[derive(Debug, Clone, PartialEq)]
 pub enum VariableMember<'a> {
     /// `foo.bar` in `v.foo.bar`
-    Object { object: Box<VariableMember<'a>>, property: IdentifierReference<'a> },
+    Object { object: Box<VariableMember<'a>>, property: Identifier<'a> },
     /// `foo` in `v.foo`
-    Property { property: IdentifierReference<'a> },
+    Property { property: Identifier<'a> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -475,7 +475,7 @@ impl<'a> From<ConditionalExpression<'a>> for Expression<'a> {
 pub struct ResourceExpression<'a> {
     pub span: Span,
     pub section: ResourceSection,
-    pub name: IdentifierReference<'a>,
+    pub name: Identifier<'a>,
 }
 
 impl<'a> From<ResourceExpression<'a>> for Expression<'a> {
@@ -523,7 +523,7 @@ impl From<Kind> for ResourceSection {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ArrayAccessExpression<'a> {
     pub span: Span,
-    pub name: IdentifierReference<'a>,
+    pub name: Identifier<'a>,
     pub index: Expression<'a>,
 }
 
@@ -557,7 +557,7 @@ impl<'a> From<ArrowAccessExpression<'a>> for Expression<'a> {
 pub struct CallExpression<'a> {
     pub span: Span,
     pub kind: CallKind,
-    pub callee: IdentifierReference<'a>,
+    pub callee: Identifier<'a>,
     pub arguments: Option<Vec<Expression<'a>>>,
 }
 

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -243,7 +243,7 @@ impl Print for Expression<'_> {
     }
 }
 
-impl Print for IdentifierReference<'_> {
+impl Print for Identifier<'_> {
     fn print(&self, c: &mut Codegen) {
         c.print_str(self.name);
     }

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -245,7 +245,7 @@ impl Print for Expression<'_> {
 
 impl Print for Identifier<'_> {
     fn print(&self, c: &mut Codegen) {
-        c.print_str(self.name);
+        c.print_str(&self.name);
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -273,14 +273,14 @@ impl<'a> Parser<'a> {
     }
 
     #[inline(always)] // Hot path
-    fn parse_identifier_reference(&mut self) -> Result<IdentifierReference<'a>> {
+    fn parse_identifier(&mut self) -> Result<Identifier<'a>> {
         let span = self.start_span();
         let name = self.current_src();
         match self.current_kind() {
             v if v.is_variable() | v.is_call() => self.bump(),
             _ => self.expect(Kind::Identifier)?,
         }
-        Ok(IdentifierReference { span: self.end_span(span), name })
+        Ok(Identifier { span: self.end_span(span), name })
     }
 
     fn parse_parenthesized_expression(&mut self) -> Result<Expression<'a>> {
@@ -409,10 +409,10 @@ impl<'a> Parser<'a> {
         let lifetime: VariableLifetime = self.current_kind().into();
         self.bump();
         self.expect(Kind::Dot)?;
-        let property = self.parse_identifier_reference()?;
+        let property = self.parse_identifier()?;
         let mut member = VariableMember::Property { property };
         while self.eat(Kind::Dot) {
-            let property = self.parse_identifier_reference()?;
+            let property = self.parse_identifier()?;
             member = VariableMember::Object { object: member.into(), property };
         }
         Ok(VariableExpression { span: self.end_span(span), lifetime, member })
@@ -423,7 +423,7 @@ impl<'a> Parser<'a> {
         let section: ResourceSection = self.current_kind().into();
         self.bump();
         self.expect(Kind::Dot)?;
-        let name = self.parse_identifier_reference()?;
+        let name = self.parse_identifier()?;
         Ok(ResourceExpression { span: self.end_span(span), section, name }.into())
     }
 
@@ -431,7 +431,7 @@ impl<'a> Parser<'a> {
         let span = self.start_span();
         self.expect(Kind::Array)?;
         self.expect(Kind::Dot)?;
-        let name = self.parse_identifier_reference()?;
+        let name = self.parse_identifier()?;
         self.expect(Kind::LeftBracket)?;
         let index = self.parse_expression(0)?;
         self.expect(Kind::RightBracket)?;
@@ -453,7 +453,7 @@ impl<'a> Parser<'a> {
         let kind: CallKind = self.current_kind().into();
         self.bump();
         self.expect(Kind::Dot)?;
-        let callee = self.parse_identifier_reference()?;
+        let callee = self.parse_identifier()?;
         let arguments = if self.eat(Kind::LeftParen) {
             let mut arguments = Vec::new();
             let mut first = true;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -280,7 +280,7 @@ impl<'a> Parser<'a> {
             v if v.is_variable() | v.is_call() => self.bump(),
             _ => self.expect(Kind::Identifier)?,
         }
-        Ok(Identifier { span: self.end_span(span), name })
+        Ok(Identifier { span: self.end_span(span), name: name.into() })
     }
 
     fn parse_parenthesized_expression(&mut self) -> Result<Expression<'a>> {

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -74,10 +74,10 @@ pub trait Traverse<'a>: Sized {
     fn exit_expression(&mut self, it: &mut Expression<'a>) {}
 
     #[inline]
-    fn enter_identifier_reference(&mut self, it: &mut IdentifierReference<'a>) {}
+    fn enter_identifier_reference(&mut self, it: &mut Identifier<'a>) {}
 
     #[inline]
-    fn exit_identifier_reference(&mut self, it: &mut IdentifierReference<'a>) {}
+    fn exit_identifier_reference(&mut self, it: &mut Identifier<'a>) {}
 
     #[inline]
     fn enter_numeric_literal(&mut self, it: &mut NumericLiteral<'a>) {}
@@ -277,10 +277,7 @@ fn walk_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut Expression<'a
     traverser.exit_expression(it);
 }
 
-fn walk_identifier_reference<'a>(
-    traverser: &mut impl Traverse<'a>,
-    it: &mut IdentifierReference<'a>,
-) {
+fn walk_identifier_reference<'a>(traverser: &mut impl Traverse<'a>, it: &mut Identifier<'a>) {
     traverser.enter_identifier_reference(it);
     traverser.exit_identifier_reference(it);
 }

--- a/tests/snapshots/parser__array_access.snap
+++ b/tests/snapshots/parser__array_access.snap
@@ -16,7 +16,7 @@ ParseResult {
                         start: 0,
                         end: 16,
                     },
-                    name: IdentifierReference {
+                    name: Identifier {
                         span: Span {
                             start: 6,
                             end: 9,
@@ -30,7 +30,7 @@ ParseResult {
                                 end: 15,
                             },
                             kind: Query,
-                            callee: IdentifierReference {
+                            callee: Identifier {
                                 span: Span {
                                     start: 12,
                                     end: 15,

--- a/tests/snapshots/parser__arrow_access.snap
+++ b/tests/snapshots/parser__arrow_access.snap
@@ -24,7 +24,7 @@ ParseResult {
                             },
                             lifetime: Variable,
                             member: Property {
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 2,
                                         end: 5,
@@ -42,7 +42,7 @@ ParseResult {
                             },
                             lifetime: Variable,
                             member: Property {
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 9,
                                         end: 12,

--- a/tests/snapshots/parser__assignment.snap
+++ b/tests/snapshots/parser__assignment.snap
@@ -26,7 +26,7 @@ ParseResult {
                             member: Object {
                                 object: Object {
                                     object: Property {
-                                        property: IdentifierReference {
+                                        property: Identifier {
                                             span: Span {
                                                 start: 2,
                                                 end: 5,
@@ -34,7 +34,7 @@ ParseResult {
                                             name: "cow",
                                         },
                                     },
-                                    property: IdentifierReference {
+                                    property: Identifier {
                                         span: Span {
                                             start: 6,
                                             end: 14,
@@ -42,7 +42,7 @@ ParseResult {
                                         name: "location",
                                     },
                                 },
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 15,
                                         end: 16,
@@ -78,7 +78,7 @@ ParseResult {
                             member: Object {
                                 object: Object {
                                     object: Property {
-                                        property: IdentifierReference {
+                                        property: Identifier {
                                             span: Span {
                                                 start: 29,
                                                 end: 32,
@@ -86,7 +86,7 @@ ParseResult {
                                             name: "cow",
                                         },
                                     },
-                                    property: IdentifierReference {
+                                    property: Identifier {
                                         span: Span {
                                             start: 33,
                                             end: 41,
@@ -94,7 +94,7 @@ ParseResult {
                                         name: "location",
                                     },
                                 },
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 42,
                                         end: 43,
@@ -130,7 +130,7 @@ ParseResult {
                             member: Object {
                                 object: Object {
                                     object: Property {
-                                        property: IdentifierReference {
+                                        property: Identifier {
                                             span: Span {
                                                 start: 52,
                                                 end: 55,
@@ -138,7 +138,7 @@ ParseResult {
                                             name: "cow",
                                         },
                                     },
-                                    property: IdentifierReference {
+                                    property: Identifier {
                                         span: Span {
                                             start: 56,
                                             end: 64,
@@ -146,7 +146,7 @@ ParseResult {
                                         name: "location",
                                     },
                                 },
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 65,
                                         end: 66,

--- a/tests/snapshots/parser__complex_parenthesized_expression.snap
+++ b/tests/snapshots/parser__complex_parenthesized_expression.snap
@@ -33,7 +33,7 @@ ParseResult {
                                                 },
                                                 lifetime: Variable,
                                                 member: Property {
-                                                    property: IdentifierReference {
+                                                    property: Identifier {
                                                         span: Span {
                                                             start: 3,
                                                             end: 4,
@@ -75,7 +75,7 @@ ParseResult {
                                                 },
                                                 lifetime: Variable,
                                                 member: Property {
-                                                    property: IdentifierReference {
+                                                    property: Identifier {
                                                         span: Span {
                                                             start: 12,
                                                             end: 13,

--- a/tests/snapshots/parser__conditional.snap
+++ b/tests/snapshots/parser__conditional.snap
@@ -23,7 +23,7 @@ ParseResult {
                                 end: 5,
                             },
                             kind: Query,
-                            callee: IdentifierReference {
+                            callee: Identifier {
                                 span: Span {
                                     start: 2,
                                     end: 5,

--- a/tests/snapshots/parser__for_each.snap
+++ b/tests/snapshots/parser__for_each.snap
@@ -24,7 +24,7 @@ ParseResult {
                             },
                             lifetime: Variable,
                             member: Property {
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 11,
                                         end: 12,
@@ -40,7 +40,7 @@ ParseResult {
                                     end: 19,
                                 },
                                 kind: Query,
-                                callee: IdentifierReference {
+                                callee: Identifier {
                                     span: Span {
                                         start: 16,
                                         end: 19,
@@ -69,7 +69,7 @@ ParseResult {
                                             },
                                             lifetime: Variable,
                                             member: Property {
-                                                property: IdentifierReference {
+                                                property: Identifier {
                                                     span: Span {
                                                         start: 24,
                                                         end: 25,
@@ -92,7 +92,7 @@ ParseResult {
                                                         },
                                                         lifetime: Variable,
                                                         member: Property {
-                                                            property: IdentifierReference {
+                                                            property: Identifier {
                                                                 span: Span {
                                                                     start: 30,
                                                                     end: 31,

--- a/tests/snapshots/parser__loop.snap
+++ b/tests/snapshots/parser__loop.snap
@@ -46,7 +46,7 @@ ParseResult {
                                             },
                                             lifetime: Variable,
                                             member: Property {
-                                                property: IdentifierReference {
+                                                property: Identifier {
                                                     span: Span {
                                                         start: 12,
                                                         end: 13,
@@ -69,7 +69,7 @@ ParseResult {
                                                         },
                                                         lifetime: Variable,
                                                         member: Property {
-                                                            property: IdentifierReference {
+                                                            property: Identifier {
                                                                 span: Span {
                                                                     start: 18,
                                                                     end: 19,

--- a/tests/snapshots/parser__missing_semi_with_assignment.snap
+++ b/tests/snapshots/parser__missing_semi_with_assignment.snap
@@ -24,7 +24,7 @@ ParseResult {
                             },
                             lifetime: Variable,
                             member: Property {
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 2,
                                         end: 3,
@@ -54,7 +54,7 @@ ParseResult {
                             },
                             lifetime: Variable,
                             member: Property {
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 11,
                                         end: 12,

--- a/tests/snapshots/parser__null_operation.snap
+++ b/tests/snapshots/parser__null_operation.snap
@@ -24,7 +24,7 @@ ParseResult {
                             },
                             lifetime: Variable,
                             member: Property {
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 2,
                                         end: 3,

--- a/tests/snapshots/parser__resource_geometry.snap
+++ b/tests/snapshots/parser__resource_geometry.snap
@@ -17,7 +17,7 @@ ParseResult {
                         end: 12,
                     },
                     section: Geometry,
-                    name: IdentifierReference {
+                    name: Identifier {
                         span: Span {
                             start: 9,
                             end: 12,

--- a/tests/snapshots/parser__resource_material.snap
+++ b/tests/snapshots/parser__resource_material.snap
@@ -17,7 +17,7 @@ ParseResult {
                         end: 12,
                     },
                     section: Material,
-                    name: IdentifierReference {
+                    name: Identifier {
                         span: Span {
                             start: 9,
                             end: 12,

--- a/tests/snapshots/parser__resource_texture.snap
+++ b/tests/snapshots/parser__resource_texture.snap
@@ -17,7 +17,7 @@ ParseResult {
                         end: 11,
                     },
                     section: Texture,
-                    name: IdentifierReference {
+                    name: Identifier {
                         span: Span {
                             start: 8,
                             end: 11,

--- a/tests/snapshots/parser__return.snap
+++ b/tests/snapshots/parser__return.snap
@@ -25,7 +25,7 @@ ParseResult {
                                 },
                                 lifetime: Variable,
                                 member: Property {
-                                    property: IdentifierReference {
+                                    property: Identifier {
                                         span: Span {
                                             start: 9,
                                             end: 10,

--- a/tests/snapshots/parser__ternary_double_left.snap
+++ b/tests/snapshots/parser__ternary_double_left.snap
@@ -23,7 +23,7 @@ ParseResult {
                                 end: 5,
                             },
                             kind: Query,
-                            callee: IdentifierReference {
+                            callee: Identifier {
                                 span: Span {
                                     start: 2,
                                     end: 5,
@@ -53,7 +53,7 @@ ParseResult {
                                             },
                                             lifetime: Variable,
                                             member: Property {
-                                                property: IdentifierReference {
+                                                property: Identifier {
                                                     span: Span {
                                                         start: 10,
                                                         end: 13,

--- a/tests/snapshots/parser__ternary_double_right.snap
+++ b/tests/snapshots/parser__ternary_double_right.snap
@@ -23,7 +23,7 @@ ParseResult {
                                 end: 5,
                             },
                             kind: Query,
-                            callee: IdentifierReference {
+                            callee: Identifier {
                                 span: Span {
                                     start: 2,
                                     end: 5,
@@ -63,7 +63,7 @@ ParseResult {
                                             },
                                             lifetime: Variable,
                                             member: Property {
-                                                property: IdentifierReference {
+                                                property: Identifier {
                                                     span: Span {
                                                         start: 14,
                                                         end: 17,

--- a/tests/snapshots/parser__variable_c.snap
+++ b/tests/snapshots/parser__variable_c.snap
@@ -18,7 +18,7 @@ ParseResult {
                     },
                     lifetime: Context,
                     member: Property {
-                        property: IdentifierReference {
+                        property: Identifier {
                             span: Span {
                                 start: 2,
                                 end: 5,

--- a/tests/snapshots/parser__variable_context.snap
+++ b/tests/snapshots/parser__variable_context.snap
@@ -18,7 +18,7 @@ ParseResult {
                     },
                     lifetime: Context,
                     member: Property {
-                        property: IdentifierReference {
+                        property: Identifier {
                             span: Span {
                                 start: 8,
                                 end: 11,

--- a/tests/snapshots/parser__variable_t.snap
+++ b/tests/snapshots/parser__variable_t.snap
@@ -18,7 +18,7 @@ ParseResult {
                     },
                     lifetime: Temporary,
                     member: Property {
-                        property: IdentifierReference {
+                        property: Identifier {
                             span: Span {
                                 start: 2,
                                 end: 5,

--- a/tests/snapshots/parser__variable_temp.snap
+++ b/tests/snapshots/parser__variable_temp.snap
@@ -18,7 +18,7 @@ ParseResult {
                     },
                     lifetime: Temporary,
                     member: Property {
-                        property: IdentifierReference {
+                        property: Identifier {
                             span: Span {
                                 start: 5,
                                 end: 8,

--- a/tests/snapshots/parser__variable_v.snap
+++ b/tests/snapshots/parser__variable_v.snap
@@ -18,7 +18,7 @@ ParseResult {
                     },
                     lifetime: Variable,
                     member: Property {
-                        property: IdentifierReference {
+                        property: Identifier {
                             span: Span {
                                 start: 2,
                                 end: 5,

--- a/tests/snapshots/parser__variable_variable.snap
+++ b/tests/snapshots/parser__variable_variable.snap
@@ -18,7 +18,7 @@ ParseResult {
                     },
                     lifetime: Variable,
                     member: Property {
-                        property: IdentifierReference {
+                        property: Identifier {
                             span: Span {
                                 start: 9,
                                 end: 12,

--- a/tests/snapshots/parser__weird_variable_members.snap
+++ b/tests/snapshots/parser__weird_variable_members.snap
@@ -28,7 +28,7 @@ ParseResult {
                                                     object: Object {
                                                         object: Object {
                                                             object: Property {
-                                                                property: IdentifierReference {
+                                                                property: Identifier {
                                                                     span: Span {
                                                                         start: 9,
                                                                         end: 10,
@@ -36,7 +36,7 @@ ParseResult {
                                                                     name: "v",
                                                                 },
                                                             },
-                                                            property: IdentifierReference {
+                                                            property: Identifier {
                                                                 span: Span {
                                                                     start: 11,
                                                                     end: 15,
@@ -44,7 +44,7 @@ ParseResult {
                                                                 name: "temp",
                                                             },
                                                         },
-                                                        property: IdentifierReference {
+                                                        property: Identifier {
                                                             span: Span {
                                                                 start: 16,
                                                                 end: 17,
@@ -52,7 +52,7 @@ ParseResult {
                                                             name: "t",
                                                         },
                                                     },
-                                                    property: IdentifierReference {
+                                                    property: Identifier {
                                                         span: Span {
                                                             start: 18,
                                                             end: 25,
@@ -60,7 +60,7 @@ ParseResult {
                                                         name: "context",
                                                     },
                                                 },
-                                                property: IdentifierReference {
+                                                property: Identifier {
                                                     span: Span {
                                                         start: 26,
                                                         end: 27,
@@ -68,7 +68,7 @@ ParseResult {
                                                     name: "c",
                                                 },
                                             },
-                                            property: IdentifierReference {
+                                            property: Identifier {
                                                 span: Span {
                                                     start: 28,
                                                     end: 33,
@@ -76,7 +76,7 @@ ParseResult {
                                                 name: "query",
                                             },
                                         },
-                                        property: IdentifierReference {
+                                        property: Identifier {
                                             span: Span {
                                                 start: 34,
                                                 end: 35,
@@ -84,7 +84,7 @@ ParseResult {
                                             name: "q",
                                         },
                                     },
-                                    property: IdentifierReference {
+                                    property: Identifier {
                                         span: Span {
                                             start: 36,
                                             end: 40,
@@ -92,7 +92,7 @@ ParseResult {
                                         name: "math",
                                     },
                                 },
-                                property: IdentifierReference {
+                                property: Identifier {
                                     span: Span {
                                         start: 41,
                                         end: 42,
@@ -100,7 +100,7 @@ ParseResult {
                                     name: "a",
                                 },
                             },
-                            property: IdentifierReference {
+                            property: Identifier {
                                 span: Span {
                                     start: 43,
                                     end: 44,
@@ -108,7 +108,7 @@ ParseResult {
                                 name: "b",
                             },
                         },
-                        property: IdentifierReference {
+                        property: Identifier {
                             span: Span {
                                 start: 45,
                                 end: 46,


### PR DESCRIPTION
Renamed `IdentifierReference` to `Identifier`. The node is used in variable members which don't treat the id as a reference, so generalizing would make more sense.

Additionally made `name` use `Cow<'a, str>`. This will help in #24 where we need to construct identifiers with owned strings.