### PR TITLE
fix(codegen): avoid indenting in `LoopStatement` with pretty printing

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -174,7 +174,7 @@ impl Print for AssignmentStatement<'_> {
 impl Print for LoopStatement<'_> {
     fn print(&self, c: &mut Codegen) {
         c.print_str("loop");
-        c.print_scope('(', ')', |c| {
+        c.print_wrapped('(', ')', |c| {
             self.count.print(c);
             c.print_comma();
             c.print_space();


### PR DESCRIPTION
`LoopStatement` was using `Codegen::print_scope()` which adds indentation when `minify` is false. We should probably have tests for pretty printing as well but that will be for another day.