### PR TITLE
fix(parser): semicolon handling in different expressions/statements

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -41,6 +41,12 @@ pub enum Statement<'a> {
     Empty(Box<EmptyStatement>),
 }
 
+impl Statement<'_> {
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty(_))
+    }
+}
+
 /// `v.a = 0;`
 #[derive(Debug, Clone, PartialEq)]
 pub struct AssignmentStatement<'a> {
@@ -185,7 +191,7 @@ impl<'a> From<ReturnStatement<'a>> for Statement<'a> {
 /// <https://bedrock.dev/docs/stable/Molang#break>
 ///
 /// `break` in `loop(10, { v.x = v.x + 1; (v.x > 20) ? break; });`
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BreakStatement {
     pub span: Span,
 }
@@ -199,7 +205,7 @@ impl From<BreakStatement> for Statement<'_> {
 /// <https://bedrock.dev/docs/stable/Molang#continue>
 ///
 /// `continue` in `loop(10, { (v.x > 5) ? continue; v.x = v.x + 1; });`
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ContinueStatement {
     pub span: Span,
 }
@@ -210,7 +216,7 @@ impl From<ContinueStatement> for Statement<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct EmptyStatement {
     pub span: Span,
 }

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -149,8 +149,15 @@ pub mod errors {
     }
 
     #[cold]
+    pub fn semi_required_in_parenthesized_expression(span: Span) -> Diagnostic {
+        Diagnostic::error("Statements inside `()` must be delimited by `;` if the other statements also end with `;`")
+            .with_help("Try inserting a semicolon here")
+            .with_label(span)
+    }
+
+    #[cold]
     pub fn semi_required_in_block_expression(span: Span) -> Diagnostic {
-        Diagnostic::error("Expressions inside `{}` must be delimited by `;`")
+        Diagnostic::error("Statements inside `{}` must be delimited by `;`")
             .with_help("Try inserting a semicolon here")
             .with_label(span)
     }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -244,6 +244,19 @@ fn r#loop() {
 }
 
 #[test]
+fn loop_in_block() {
+    let out = parse(
+        "
+            {
+                v.i = 1;
+                loop(10, {v.i = v.i + 1;});
+            };
+        ",
+    );
+    assert_snapshot!(out);
+}
+
+#[test]
 fn loop_in_expression() {
     let out = parse("1 + loop(10, {0;})");
     assert_snapshot!(out);
@@ -319,11 +332,11 @@ fn illegal_update_operation_with_context() {
 fn semisemisemisemi() {
     let out = parse(
         "
-        ;;;;;;; ;;;;;;; ;;;    ;;; ;;
-        ;;      ;;      ;;;;  ;;;; ;;
-        ;;;;;;; ;;;;;   ;; ;;;; ;; ;;
-             ;; ;;      ;;  ;;  ;; ;;
-        ;;;;;;; ;;;;;;; ;;      ;; ;;
+            ;;;;;;; ;;;;;;; ;;;    ;;; ;;
+            ;;      ;;      ;;;;  ;;;; ;;
+            ;;;;;;; ;;;;;   ;; ;;;; ;; ;;
+                 ;; ;;      ;;  ;;  ;; ;;
+            ;;;;;;; ;;;;;;; ;;      ;; ;;
         ",
     );
     assert_snapshot!(out);

--- a/tests/snapshots/parser__block_undelimited.snap
+++ b/tests/snapshots/parser__block_undelimited.snap
@@ -41,7 +41,7 @@ ParseResult {
     errors: [
         Diagnostic {
             inner: DiagnosticInner {
-                message: "Expressions inside `{}` must be delimited by `;`",
+                message: "Statements inside `{}` must be delimited by `;`",
                 labels: Some(
                     [
                         LabeledSpan {

--- a/tests/snapshots/parser__complex_parenthesized_expression.snap
+++ b/tests/snapshots/parser__complex_parenthesized_expression.snap
@@ -55,14 +55,6 @@ ParseResult {
                                             ),
                                         },
                                     ),
-                                    Empty(
-                                        EmptyStatement {
-                                            span: Span {
-                                                start: 8,
-                                                end: 9,
-                                            },
-                                        },
-                                    ),
                                     Assignment(
                                         AssignmentStatement {
                                             span: Span {

--- a/tests/snapshots/parser__loop_in_block.snap
+++ b/tests/snapshots/parser__loop_in_block.snap
@@ -1,0 +1,154 @@
+---
+source: tests/parser.rs
+expression: out
+---
+ParseResult {
+    program: Program {
+        span: Span {
+            start: 13,
+            end: 98,
+        },
+        source: "\n            {\n                v.i = 1;\n                loop(10, {v.i = v.i + 1;});\n            };\n        ",
+        body: Complex(
+            [
+                Expression(
+                    Block(
+                        BlockExpression {
+                            span: Span {
+                                start: 13,
+                                end: 97,
+                            },
+                            statements: [
+                                Assignment(
+                                    AssignmentStatement {
+                                        span: Span {
+                                            start: 31,
+                                            end: 38,
+                                        },
+                                        left: VariableExpression {
+                                            span: Span {
+                                                start: 31,
+                                                end: 34,
+                                            },
+                                            lifetime: Variable,
+                                            member: Property {
+                                                property: Identifier {
+                                                    span: Span {
+                                                        start: 33,
+                                                        end: 34,
+                                                    },
+                                                    name: "i",
+                                                },
+                                            },
+                                        },
+                                        operator: Assign,
+                                        right: NumericLiteral(
+                                            NumericLiteral {
+                                                span: Span {
+                                                    start: 37,
+                                                    end: 38,
+                                                },
+                                                value: 1.0,
+                                                raw: "1",
+                                            },
+                                        ),
+                                    },
+                                ),
+                                Loop(
+                                    LoopStatement {
+                                        span: Span {
+                                            start: 56,
+                                            end: 82,
+                                        },
+                                        count: NumericLiteral(
+                                            NumericLiteral {
+                                                span: Span {
+                                                    start: 61,
+                                                    end: 63,
+                                                },
+                                                value: 10.0,
+                                                raw: "10",
+                                            },
+                                        ),
+                                        block: BlockExpression {
+                                            span: Span {
+                                                start: 65,
+                                                end: 81,
+                                            },
+                                            statements: [
+                                                Assignment(
+                                                    AssignmentStatement {
+                                                        span: Span {
+                                                            start: 66,
+                                                            end: 79,
+                                                        },
+                                                        left: VariableExpression {
+                                                            span: Span {
+                                                                start: 66,
+                                                                end: 69,
+                                                            },
+                                                            lifetime: Variable,
+                                                            member: Property {
+                                                                property: Identifier {
+                                                                    span: Span {
+                                                                        start: 68,
+                                                                        end: 69,
+                                                                    },
+                                                                    name: "i",
+                                                                },
+                                                            },
+                                                        },
+                                                        operator: Assign,
+                                                        right: Binary(
+                                                            BinaryExpression {
+                                                                span: Span {
+                                                                    start: 72,
+                                                                    end: 79,
+                                                                },
+                                                                left: Variable(
+                                                                    VariableExpression {
+                                                                        span: Span {
+                                                                            start: 72,
+                                                                            end: 75,
+                                                                        },
+                                                                        lifetime: Variable,
+                                                                        member: Property {
+                                                                            property: Identifier {
+                                                                                span: Span {
+                                                                                    start: 74,
+                                                                                    end: 75,
+                                                                                },
+                                                                                name: "i",
+                                                                            },
+                                                                        },
+                                                                    },
+                                                                ),
+                                                                operator: Addition,
+                                                                right: NumericLiteral(
+                                                                    NumericLiteral {
+                                                                        span: Span {
+                                                                            start: 78,
+                                                                            end: 79,
+                                                                        },
+                                                                        value: 1.0,
+                                                                        raw: "1",
+                                                                    },
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    },
+                                ),
+                            ],
+                        },
+                    ),
+                ),
+            ],
+        ),
+    },
+    errors: [],
+    panicked: false,
+}

--- a/tests/snapshots/parser__semisemisemisemi.snap
+++ b/tests/snapshots/parser__semisemisemisemi.snap
@@ -5,52 +5,12 @@ expression: out
 ParseResult {
     program: Program {
         span: Span {
-            start: 9,
-            end: 190,
+            start: 13,
+            end: 210,
         },
-        source: "\n        ;;;;;;; ;;;;;;; ;;;    ;;; ;;\n        ;;      ;;      ;;;;  ;;;; ;;\n        ;;;;;;; ;;;;;   ;; ;;;; ;; ;;\n             ;; ;;      ;;  ;;  ;; ;;\n        ;;;;;;; ;;;;;;; ;;      ;; ;;\n        ",
+        source: "\n            ;;;;;;; ;;;;;;; ;;;    ;;; ;;\n            ;;      ;;      ;;;;  ;;;; ;;\n            ;;;;;;; ;;;;;   ;; ;;;; ;; ;;\n                 ;; ;;      ;;  ;;  ;; ;;\n            ;;;;;;; ;;;;;;; ;;      ;; ;;\n        ",
         body: Complex(
             [
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 9,
-                            end: 10,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 10,
-                            end: 11,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 11,
-                            end: 12,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 12,
-                            end: 13,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 13,
-                            end: 14,
-                        },
-                    },
-                ),
                 Empty(
                     EmptyStatement {
                         span: Span {
@@ -64,6 +24,14 @@ ParseResult {
                         span: Span {
                             start: 15,
                             end: 16,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 16,
+                            end: 17,
                         },
                     },
                 ),
@@ -94,14 +62,6 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 20,
-                            end: 21,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
                             start: 21,
                             end: 22,
                         },
@@ -120,6 +80,14 @@ ParseResult {
                         span: Span {
                             start: 23,
                             end: 24,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 24,
+                            end: 25,
                         },
                     },
                 ),
@@ -150,24 +118,24 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 32,
-                            end: 33,
+                            start: 29,
+                            end: 30,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 33,
-                            end: 34,
+                            start: 30,
+                            end: 31,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 34,
-                            end: 35,
+                            start: 31,
+                            end: 32,
                         },
                     },
                 ),
@@ -190,16 +158,24 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 47,
-                            end: 48,
+                            start: 38,
+                            end: 39,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 48,
-                            end: 49,
+                            start: 40,
+                            end: 41,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 41,
+                            end: 42,
                         },
                     },
                 ),
@@ -238,38 +214,6 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 65,
-                            end: 66,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 66,
-                            end: 67,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 69,
-                            end: 70,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 70,
-                            end: 71,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
                             start: 71,
                             end: 72,
                         },
@@ -286,6 +230,14 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
+                            start: 73,
+                            end: 74,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
                             start: 74,
                             end: 75,
                         },
@@ -294,96 +246,48 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 75,
-                            end: 76,
+                            start: 77,
+                            end: 78,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 85,
-                            end: 86,
+                            start: 78,
+                            end: 79,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 86,
-                            end: 87,
+                            start: 79,
+                            end: 80,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 87,
-                            end: 88,
+                            start: 80,
+                            end: 81,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 88,
-                            end: 89,
+                            start: 82,
+                            end: 83,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 89,
-                            end: 90,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 90,
-                            end: 91,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 91,
-                            end: 92,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 93,
-                            end: 94,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 94,
-                            end: 95,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 95,
-                            end: 96,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 96,
-                            end: 97,
+                            start: 83,
+                            end: 84,
                         },
                     },
                 ),
@@ -392,6 +296,30 @@ ParseResult {
                         span: Span {
                             start: 97,
                             end: 98,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 98,
+                            end: 99,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 99,
+                            end: 100,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 100,
+                            end: 101,
                         },
                     },
                 ),
@@ -414,8 +342,8 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 104,
-                            end: 105,
+                            start: 103,
+                            end: 104,
                         },
                     },
                 ),
@@ -446,24 +374,16 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
+                            start: 108,
+                            end: 109,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
                             start: 109,
                             end: 110,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 110,
-                            end: 111,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 112,
-                            end: 113,
                         },
                     },
                 ),
@@ -478,56 +398,72 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 128,
-                            end: 129,
+                            start: 114,
+                            end: 115,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 129,
-                            end: 130,
+                            start: 116,
+                            end: 117,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 131,
-                            end: 132,
+                            start: 117,
+                            end: 118,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 132,
-                            end: 133,
+                            start: 118,
+                            end: 119,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 139,
-                            end: 140,
+                            start: 119,
+                            end: 120,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 140,
-                            end: 141,
+                            start: 121,
+                            end: 122,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 143,
-                            end: 144,
+                            start: 122,
+                            end: 123,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 124,
+                            end: 125,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 125,
+                            end: 126,
                         },
                     },
                 ),
@@ -536,6 +472,14 @@ ParseResult {
                         span: Span {
                             start: 144,
                             end: 145,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 145,
+                            end: 146,
                         },
                     },
                 ),
@@ -558,32 +502,32 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 150,
-                            end: 151,
+                            start: 155,
+                            end: 156,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 151,
-                            end: 152,
+                            start: 156,
+                            end: 157,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 161,
-                            end: 162,
+                            start: 159,
+                            end: 160,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 162,
-                            end: 163,
+                            start: 160,
+                            end: 161,
                         },
                     },
                 ),
@@ -606,14 +550,6 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 165,
-                            end: 166,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
                             start: 166,
                             end: 167,
                         },
@@ -630,72 +566,32 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 169,
-                            end: 170,
+                            start: 181,
+                            end: 182,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 170,
-                            end: 171,
+                            start: 182,
+                            end: 183,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 171,
-                            end: 172,
+                            start: 183,
+                            end: 184,
                         },
                     },
                 ),
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 172,
-                            end: 173,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 173,
-                            end: 174,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 174,
-                            end: 175,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 175,
-                            end: 176,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 177,
-                            end: 178,
-                        },
-                    },
-                ),
-                Empty(
-                    EmptyStatement {
-                        span: Span {
-                            start: 178,
-                            end: 179,
+                            start: 184,
+                            end: 185,
                         },
                     },
                 ),
@@ -718,8 +614,8 @@ ParseResult {
                 Empty(
                     EmptyStatement {
                         span: Span {
-                            start: 188,
-                            end: 189,
+                            start: 187,
+                            end: 188,
                         },
                     },
                 ),
@@ -728,6 +624,110 @@ ParseResult {
                         span: Span {
                             start: 189,
                             end: 190,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 190,
+                            end: 191,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 191,
+                            end: 192,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 192,
+                            end: 193,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 193,
+                            end: 194,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 194,
+                            end: 195,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 195,
+                            end: 196,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 197,
+                            end: 198,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 198,
+                            end: 199,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 205,
+                            end: 206,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 206,
+                            end: 207,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 208,
+                            end: 209,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 209,
+                            end: 210,
+                        },
+                    },
+                ),
+                Empty(
+                    EmptyStatement {
+                        span: Span {
+                            start: 219,
+                            end: 220,
                         },
                     },
                 ),


### PR DESCRIPTION
Previously parsing statements was handled manually in each scope where a statement was expected. I abstracted it away alongside semicolon parsing to two methods. They're used appropriately in different contexts to either require a semicolon or optionally consume a semicolon and try to parse more statements (in case of parenthesized expressions).