### PR TITLE
refactor(ast, parser): rename lifetime `'a` to `'src`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5,17 +5,17 @@ use crate::{span::Span, token::Kind};
 /// Represents the root of a Molang expression AST, containing all the top-level
 /// information.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Program<'a> {
+pub struct Program<'src> {
     pub span: Span,
-    pub source: &'a str,
-    pub body: ProgramBody<'a>,
+    pub source: &'src str,
+    pub body: ProgramBody<'src>,
 }
 
 /// A program is considered complex if it contains any statement.
 #[derive(Debug, Clone, PartialEq)]
-pub enum ProgramBody<'a> {
-    Simple(Expression<'a>),
-    Complex(Vec<Statement<'a>>),
+pub enum ProgramBody<'src> {
+    Simple(Expression<'src>),
+    Complex(Vec<Statement<'src>>),
     Empty,
 }
 
@@ -30,12 +30,12 @@ impl ProgramBody<'_> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Statement<'a> {
-    Expression(Box<Expression<'a>>),
-    Assignment(Box<AssignmentStatement<'a>>),
-    Loop(Box<LoopStatement<'a>>),
-    ForEach(Box<ForEachStatement<'a>>),
-    Return(Box<ReturnStatement<'a>>),
+pub enum Statement<'src> {
+    Expression(Box<Expression<'src>>),
+    Assignment(Box<AssignmentStatement<'src>>),
+    Loop(Box<LoopStatement<'src>>),
+    ForEach(Box<ForEachStatement<'src>>),
+    Return(Box<ReturnStatement<'src>>),
     Break(Box<BreakStatement>),
     Continue(Box<ContinueStatement>),
     Empty(Box<EmptyStatement>),
@@ -49,15 +49,15 @@ impl Statement<'_> {
 
 /// `v.a = 0;`
 #[derive(Debug, Clone, PartialEq)]
-pub struct AssignmentStatement<'a> {
+pub struct AssignmentStatement<'src> {
     pub span: Span,
-    pub left: VariableExpression<'a>,
+    pub left: VariableExpression<'src>,
     pub operator: AssignmentOperator,
-    pub right: Expression<'a>,
+    pub right: Expression<'src>,
 }
 
-impl<'a> From<AssignmentStatement<'a>> for Statement<'a> {
-    fn from(value: AssignmentStatement<'a>) -> Self {
+impl<'src> From<AssignmentStatement<'src>> for Statement<'src> {
+    fn from(value: AssignmentStatement<'src>) -> Self {
         Self::Assignment(value.into())
     }
 }
@@ -146,14 +146,14 @@ impl From<Kind> for AssignmentOperator {
 ///
 /// `loop(10, { v.x = v.x + 1; });`
 #[derive(Debug, Clone, PartialEq)]
-pub struct LoopStatement<'a> {
+pub struct LoopStatement<'src> {
     pub span: Span,
-    pub count: Expression<'a>,
-    pub block: BlockExpression<'a>,
+    pub count: Expression<'src>,
+    pub block: BlockExpression<'src>,
 }
 
-impl<'a> From<LoopStatement<'a>> for Statement<'a> {
-    fn from(value: LoopStatement<'a>) -> Self {
+impl<'src> From<LoopStatement<'src>> for Statement<'src> {
+    fn from(value: LoopStatement<'src>) -> Self {
         Self::Loop(value.into())
     }
 }
@@ -162,28 +162,28 @@ impl<'a> From<LoopStatement<'a>> for Statement<'a> {
 ///
 /// `for_each(t.foo, q.baz, { v.x = v.x + 1; });`
 #[derive(Debug, Clone, PartialEq)]
-pub struct ForEachStatement<'a> {
+pub struct ForEachStatement<'src> {
     pub span: Span,
-    pub variable: VariableExpression<'a>,
-    pub array: Expression<'a>,
-    pub block: BlockExpression<'a>,
+    pub variable: VariableExpression<'src>,
+    pub array: Expression<'src>,
+    pub block: BlockExpression<'src>,
 }
 
-impl<'a> From<ForEachStatement<'a>> for Statement<'a> {
-    fn from(value: ForEachStatement<'a>) -> Self {
+impl<'src> From<ForEachStatement<'src>> for Statement<'src> {
+    fn from(value: ForEachStatement<'src>) -> Self {
         Self::ForEach(value.into())
     }
 }
 
 /// `return` in `v.a = 1; return v.a;`
 #[derive(Debug, Clone, PartialEq)]
-pub struct ReturnStatement<'a> {
+pub struct ReturnStatement<'src> {
     pub span: Span,
-    pub argument: Expression<'a>,
+    pub argument: Expression<'src>,
 }
 
-impl<'a> From<ReturnStatement<'a>> for Statement<'a> {
-    fn from(value: ReturnStatement<'a>) -> Self {
+impl<'src> From<ReturnStatement<'src>> for Statement<'src> {
+    fn from(value: ReturnStatement<'src>) -> Self {
         Self::Return(value.into())
     }
 }
@@ -229,41 +229,41 @@ impl From<EmptyStatement> for Statement<'_> {
 
 /// <https://bedrock.dev/docs/stable/Molang#Lexical%20Structure>
 #[derive(Debug, Clone, PartialEq)]
-pub enum Expression<'a> {
-    NumericLiteral(Box<NumericLiteral<'a>>),
+pub enum Expression<'src> {
+    NumericLiteral(Box<NumericLiteral<'src>>),
     BooleanLiteral(Box<BooleanLiteral>),
-    StringLiteral(Box<StringLiteral<'a>>),
-    Variable(Box<VariableExpression<'a>>),
-    Parenthesized(Box<ParenthesizedExpression<'a>>),
-    Block(Box<BlockExpression<'a>>),
-    Binary(Box<BinaryExpression<'a>>),
-    Unary(Box<UnaryExpression<'a>>),
-    Update(Box<UpdateExpression<'a>>),
-    Ternary(Box<TernaryExpression<'a>>),
-    Conditional(Box<ConditionalExpression<'a>>),
-    Resource(Box<ResourceExpression<'a>>),
-    ArrayAccess(Box<ArrayAccessExpression<'a>>),
-    ArrowAccess(Box<ArrowAccessExpression<'a>>),
-    Call(Box<CallExpression<'a>>),
+    StringLiteral(Box<StringLiteral<'src>>),
+    Variable(Box<VariableExpression<'src>>),
+    Parenthesized(Box<ParenthesizedExpression<'src>>),
+    Block(Box<BlockExpression<'src>>),
+    Binary(Box<BinaryExpression<'src>>),
+    Unary(Box<UnaryExpression<'src>>),
+    Update(Box<UpdateExpression<'src>>),
+    Ternary(Box<TernaryExpression<'src>>),
+    Conditional(Box<ConditionalExpression<'src>>),
+    Resource(Box<ResourceExpression<'src>>),
+    ArrayAccess(Box<ArrayAccessExpression<'src>>),
+    ArrowAccess(Box<ArrowAccessExpression<'src>>),
+    Call(Box<CallExpression<'src>>),
     This(Box<ThisExpression>),
 }
 
-impl<'a> From<Expression<'a>> for Statement<'a> {
-    fn from(value: Expression<'a>) -> Self {
+impl<'src> From<Expression<'src>> for Statement<'src> {
+    fn from(value: Expression<'src>) -> Self {
         Self::Expression(value.into())
     }
 }
 
 /// `1.23` in `v.a = 1.23;`
 #[derive(Debug, Clone, PartialEq)]
-pub struct NumericLiteral<'a> {
+pub struct NumericLiteral<'src> {
     pub span: Span,
     pub value: f32,
-    pub raw: &'a str,
+    pub raw: &'src str,
 }
 
-impl<'a> From<NumericLiteral<'a>> for Expression<'a> {
-    fn from(value: NumericLiteral<'a>) -> Self {
+impl<'src> From<NumericLiteral<'src>> for Expression<'src> {
+    fn from(value: NumericLiteral<'src>) -> Self {
         Self::NumericLiteral(value.into())
     }
 }
@@ -292,30 +292,30 @@ impl BooleanLiteral {
 ///
 /// `'foo bar'` in `v.a = 'foo bar';`
 #[derive(Debug, Clone, PartialEq)]
-pub struct StringLiteral<'a> {
+pub struct StringLiteral<'src> {
     pub span: Span,
-    pub value: &'a str,
+    pub value: &'src str,
 }
 
-impl<'a> From<StringLiteral<'a>> for Expression<'a> {
-    fn from(value: StringLiteral<'a>) -> Self {
+impl<'src> From<StringLiteral<'src>> for Expression<'src> {
+    fn from(value: StringLiteral<'src>) -> Self {
         Self::StringLiteral(value.into())
     }
 }
 
 /// `foo` in `v.foo.bar`
 #[derive(Debug, Clone, PartialEq)]
-pub struct Identifier<'a> {
+pub struct Identifier<'src> {
     pub span: Span,
-    pub name: Cow<'a, str>,
+    pub name: Cow<'src, str>,
 }
 
 /// <https://bedrock.dev/docs/stable/Molang#Variables>
 #[derive(Debug, Clone, PartialEq)]
-pub struct VariableExpression<'a> {
+pub struct VariableExpression<'src> {
     pub span: Span,
     pub lifetime: VariableLifetime,
-    pub member: VariableMember<'a>,
+    pub member: VariableMember<'src>,
 }
 
 impl VariableExpression<'_> {
@@ -325,8 +325,8 @@ impl VariableExpression<'_> {
     }
 }
 
-impl<'a> From<VariableExpression<'a>> for Expression<'a> {
-    fn from(value: VariableExpression<'a>) -> Self {
+impl<'src> From<VariableExpression<'src>> for Expression<'src> {
+    fn from(value: VariableExpression<'src>) -> Self {
         Self::Variable(value.into())
     }
 }
@@ -373,57 +373,57 @@ impl From<Kind> for VariableLifetime {
 
 /// <https://bedrock.dev/docs/stable/Molang#Structs>
 #[derive(Debug, Clone, PartialEq)]
-pub enum VariableMember<'a> {
+pub enum VariableMember<'src> {
     /// `foo.bar` in `v.foo.bar`
-    Object { object: Box<VariableMember<'a>>, property: Identifier<'a> },
+    Object { object: Box<VariableMember<'src>>, property: Identifier<'src> },
     /// `foo` in `v.foo`
-    Property { property: Identifier<'a> },
+    Property { property: Identifier<'src> },
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ParenthesizedExpression<'a> {
+pub struct ParenthesizedExpression<'src> {
     pub span: Span,
-    pub body: ParenthesizedBody<'a>,
+    pub body: ParenthesizedBody<'src>,
 }
 
-impl<'a> From<ParenthesizedExpression<'a>> for Expression<'a> {
-    fn from(value: ParenthesizedExpression<'a>) -> Self {
+impl<'src> From<ParenthesizedExpression<'src>> for Expression<'src> {
+    fn from(value: ParenthesizedExpression<'src>) -> Self {
         Self::Parenthesized(value.into())
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum ParenthesizedBody<'a> {
+pub enum ParenthesizedBody<'src> {
     /// `(1 + 1)` in `(1 + 1) * 2`
-    Single(Expression<'a>),
+    Single(Expression<'src>),
     /// `(v.a = 1;)` in `(v.b = 'B'; v.a = 1;);`
-    Multiple(Vec<Statement<'a>>),
+    Multiple(Vec<Statement<'src>>),
 }
 
 /// `{ v.a = 0; }` in `loop(10, { v.a = 0; })`
 #[derive(Debug, Clone, PartialEq)]
-pub struct BlockExpression<'a> {
+pub struct BlockExpression<'src> {
     pub span: Span,
-    pub statements: Vec<Statement<'a>>,
+    pub statements: Vec<Statement<'src>>,
 }
 
-impl<'a> From<BlockExpression<'a>> for Expression<'a> {
-    fn from(value: BlockExpression<'a>) -> Self {
+impl<'src> From<BlockExpression<'src>> for Expression<'src> {
+    fn from(value: BlockExpression<'src>) -> Self {
         Self::Block(value.into())
     }
 }
 
 /// `1 + 1` in `v.a = 1 + 1;`
 #[derive(Debug, Clone, PartialEq)]
-pub struct BinaryExpression<'a> {
+pub struct BinaryExpression<'src> {
     pub span: Span,
-    pub left: Expression<'a>,
+    pub left: Expression<'src>,
     pub operator: BinaryOperator,
-    pub right: Expression<'a>,
+    pub right: Expression<'src>,
 }
 
-impl<'a> From<BinaryExpression<'a>> for Expression<'a> {
-    fn from(value: BinaryExpression<'a>) -> Self {
+impl<'src> From<BinaryExpression<'src>> for Expression<'src> {
+    fn from(value: BinaryExpression<'src>) -> Self {
         Self::Binary(value.into())
     }
 }
@@ -569,14 +569,14 @@ impl From<AssignmentOperator> for BinaryOperator {
 
 /// `-1` in `q.foo(-1)`
 #[derive(Debug, Clone, PartialEq)]
-pub struct UnaryExpression<'a> {
+pub struct UnaryExpression<'src> {
     pub span: Span,
     pub operator: UnaryOperator,
-    pub argument: Expression<'a>,
+    pub argument: Expression<'src>,
 }
 
-impl<'a> From<UnaryExpression<'a>> for Expression<'a> {
-    fn from(value: UnaryExpression<'a>) -> Self {
+impl<'src> From<UnaryExpression<'src>> for Expression<'src> {
+    fn from(value: UnaryExpression<'src>) -> Self {
         Self::Unary(value.into())
     }
 }
@@ -611,9 +611,9 @@ impl From<Kind> for UnaryOperator {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct UpdateExpression<'a> {
+pub struct UpdateExpression<'src> {
     pub span: Span,
-    pub variable: VariableExpression<'a>,
+    pub variable: VariableExpression<'src>,
     pub operator: UpdateOperator,
 }
 
@@ -658,15 +658,15 @@ impl From<UpdateOperator> for BinaryOperator {
 ///
 /// `q.foo ? 0 : 1`
 #[derive(Debug, Clone, PartialEq)]
-pub struct TernaryExpression<'a> {
+pub struct TernaryExpression<'src> {
     pub span: Span,
-    pub test: Expression<'a>,
-    pub consequent: Expression<'a>,
-    pub alternate: Expression<'a>,
+    pub test: Expression<'src>,
+    pub consequent: Expression<'src>,
+    pub alternate: Expression<'src>,
 }
 
-impl<'a> From<TernaryExpression<'a>> for Expression<'a> {
-    fn from(value: TernaryExpression<'a>) -> Self {
+impl<'src> From<TernaryExpression<'src>> for Expression<'src> {
+    fn from(value: TernaryExpression<'src>) -> Self {
         Self::Ternary(value.into())
     }
 }
@@ -675,28 +675,28 @@ impl<'a> From<TernaryExpression<'a>> for Expression<'a> {
 ///
 /// `q.foo ? 0`
 #[derive(Debug, Clone, PartialEq)]
-pub struct ConditionalExpression<'a> {
+pub struct ConditionalExpression<'src> {
     pub span: Span,
-    pub test: Expression<'a>,
-    pub consequent: Expression<'a>,
+    pub test: Expression<'src>,
+    pub consequent: Expression<'src>,
 }
 
-impl<'a> From<ConditionalExpression<'a>> for Expression<'a> {
-    fn from(value: ConditionalExpression<'a>) -> Self {
+impl<'src> From<ConditionalExpression<'src>> for Expression<'src> {
+    fn from(value: ConditionalExpression<'src>) -> Self {
         Self::Conditional(value.into())
     }
 }
 
 /// <https://bedrock.dev/docs/stable/Molang#Resource%20Expression>
 #[derive(Debug, Clone, PartialEq)]
-pub struct ResourceExpression<'a> {
+pub struct ResourceExpression<'src> {
     pub span: Span,
     pub section: ResourceSection,
-    pub name: Identifier<'a>,
+    pub name: Identifier<'src>,
 }
 
-impl<'a> From<ResourceExpression<'a>> for Expression<'a> {
-    fn from(value: ResourceExpression<'a>) -> Self {
+impl<'src> From<ResourceExpression<'src>> for Expression<'src> {
+    fn from(value: ResourceExpression<'src>) -> Self {
         Self::Resource(value.into())
     }
 }
@@ -738,14 +738,14 @@ impl From<Kind> for ResourceSection {
 ///
 /// `array.foo[0]`
 #[derive(Debug, Clone, PartialEq)]
-pub struct ArrayAccessExpression<'a> {
+pub struct ArrayAccessExpression<'src> {
     pub span: Span,
-    pub name: Identifier<'a>,
-    pub index: Expression<'a>,
+    pub name: Identifier<'src>,
+    pub index: Expression<'src>,
 }
 
-impl<'a> From<ArrayAccessExpression<'a>> for Expression<'a> {
-    fn from(value: ArrayAccessExpression<'a>) -> Self {
+impl<'src> From<ArrayAccessExpression<'src>> for Expression<'src> {
+    fn from(value: ArrayAccessExpression<'src>) -> Self {
         Self::ArrayAccess(value.into())
     }
 }
@@ -754,14 +754,14 @@ impl<'a> From<ArrayAccessExpression<'a>> for Expression<'a> {
 ///
 /// `v.foo->q.bar`
 #[derive(Debug, Clone, PartialEq)]
-pub struct ArrowAccessExpression<'a> {
+pub struct ArrowAccessExpression<'src> {
     pub span: Span,
-    pub left: Expression<'a>,
-    pub right: Expression<'a>,
+    pub left: Expression<'src>,
+    pub right: Expression<'src>,
 }
 
-impl<'a> From<ArrowAccessExpression<'a>> for Expression<'a> {
-    fn from(value: ArrowAccessExpression<'a>) -> Self {
+impl<'src> From<ArrowAccessExpression<'src>> for Expression<'src> {
+    fn from(value: ArrowAccessExpression<'src>) -> Self {
         Self::ArrowAccess(value.into())
     }
 }
@@ -771,15 +771,15 @@ impl<'a> From<ArrowAccessExpression<'a>> for Expression<'a> {
 ///
 /// `math.random(1, 2)` or `math.random`
 #[derive(Debug, Clone, PartialEq)]
-pub struct CallExpression<'a> {
+pub struct CallExpression<'src> {
     pub span: Span,
     pub kind: CallKind,
-    pub callee: Identifier<'a>,
-    pub arguments: Option<Vec<Expression<'a>>>,
+    pub callee: Identifier<'src>,
+    pub arguments: Option<Vec<Expression<'src>>>,
 }
 
-impl<'a> From<CallExpression<'a>> for Expression<'a> {
-    fn from(value: CallExpression<'a>) -> Self {
+impl<'src> From<CallExpression<'src>> for Expression<'src> {
+    fn from(value: CallExpression<'src>) -> Self {
         Self::Call(value.into())
     }
 }

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -1,53 +1,53 @@
 use crate::ast::*;
 
 /// Traverses the AST using an implementer of [`Traverse`].
-pub fn traverse<'a>(traverser: &mut impl Traverse<'a>, program: &mut Program<'a>) {
+pub fn traverse<'src>(traverser: &mut impl Traverse<'src>, program: &mut Program<'src>) {
     walk_program(traverser, program);
 }
 
 #[expect(unused_variables)]
-pub trait Traverse<'a>: Sized {
+pub trait Traverse<'src>: Sized {
     #[inline]
-    fn enter_program(&mut self, it: &mut Program<'a>) {}
+    fn enter_program(&mut self, it: &mut Program<'src>) {}
 
     #[inline]
-    fn exit_program(&mut self, it: &mut Program<'a>) {}
+    fn exit_program(&mut self, it: &mut Program<'src>) {}
 
     #[inline]
-    fn enter_statements(&mut self, it: &mut Vec<Statement<'a>>) {}
+    fn enter_statements(&mut self, it: &mut Vec<Statement<'src>>) {}
 
     #[inline]
-    fn exit_statements(&mut self, it: &mut Vec<Statement<'a>>) {}
+    fn exit_statements(&mut self, it: &mut Vec<Statement<'src>>) {}
 
     #[inline]
-    fn enter_statement(&mut self, it: &mut Statement<'a>) {}
+    fn enter_statement(&mut self, it: &mut Statement<'src>) {}
 
     #[inline]
-    fn exit_statement(&mut self, it: &mut Statement<'a>) {}
+    fn exit_statement(&mut self, it: &mut Statement<'src>) {}
 
     #[inline]
-    fn enter_assignment_statement(&mut self, it: &mut AssignmentStatement<'a>) {}
+    fn enter_assignment_statement(&mut self, it: &mut AssignmentStatement<'src>) {}
 
     #[inline]
-    fn exit_assignment_statement(&mut self, it: &mut AssignmentStatement<'a>) {}
+    fn exit_assignment_statement(&mut self, it: &mut AssignmentStatement<'src>) {}
 
     #[inline]
-    fn enter_loop_statement(&mut self, it: &mut LoopStatement<'a>) {}
+    fn enter_loop_statement(&mut self, it: &mut LoopStatement<'src>) {}
 
     #[inline]
-    fn exit_loop_statement(&mut self, it: &mut LoopStatement<'a>) {}
+    fn exit_loop_statement(&mut self, it: &mut LoopStatement<'src>) {}
 
     #[inline]
-    fn enter_for_each_statement(&mut self, it: &mut ForEachStatement<'a>) {}
+    fn enter_for_each_statement(&mut self, it: &mut ForEachStatement<'src>) {}
 
     #[inline]
-    fn exit_for_each_statement(&mut self, it: &mut ForEachStatement<'a>) {}
+    fn exit_for_each_statement(&mut self, it: &mut ForEachStatement<'src>) {}
 
     #[inline]
-    fn enter_return_statement(&mut self, it: &mut ReturnStatement<'a>) {}
+    fn enter_return_statement(&mut self, it: &mut ReturnStatement<'src>) {}
 
     #[inline]
-    fn exit_return_statement(&mut self, it: &mut ReturnStatement<'a>) {}
+    fn exit_return_statement(&mut self, it: &mut ReturnStatement<'src>) {}
 
     #[inline]
     fn enter_break_statement(&mut self, it: &mut BreakStatement) {}
@@ -68,22 +68,22 @@ pub trait Traverse<'a>: Sized {
     fn exit_empty_statement(&mut self, it: &mut EmptyStatement) {}
 
     #[inline]
-    fn enter_expression(&mut self, it: &mut Expression<'a>) {}
+    fn enter_expression(&mut self, it: &mut Expression<'src>) {}
 
     #[inline]
-    fn exit_expression(&mut self, it: &mut Expression<'a>) {}
+    fn exit_expression(&mut self, it: &mut Expression<'src>) {}
 
     #[inline]
-    fn enter_identifier_reference(&mut self, it: &mut Identifier<'a>) {}
+    fn enter_identifier_reference(&mut self, it: &mut Identifier<'src>) {}
 
     #[inline]
-    fn exit_identifier_reference(&mut self, it: &mut Identifier<'a>) {}
+    fn exit_identifier_reference(&mut self, it: &mut Identifier<'src>) {}
 
     #[inline]
-    fn enter_numeric_literal(&mut self, it: &mut NumericLiteral<'a>) {}
+    fn enter_numeric_literal(&mut self, it: &mut NumericLiteral<'src>) {}
 
     #[inline]
-    fn exit_numeric_literal(&mut self, it: &mut NumericLiteral<'a>) {}
+    fn exit_numeric_literal(&mut self, it: &mut NumericLiteral<'src>) {}
 
     #[inline]
     fn enter_boolean_literal(&mut self, it: &mut BooleanLiteral) {}
@@ -92,88 +92,88 @@ pub trait Traverse<'a>: Sized {
     fn exit_boolean_literal(&mut self, it: &mut BooleanLiteral) {}
 
     #[inline]
-    fn enter_string_literal(&mut self, it: &mut StringLiteral<'a>) {}
+    fn enter_string_literal(&mut self, it: &mut StringLiteral<'src>) {}
 
     #[inline]
-    fn exit_string_literal(&mut self, it: &mut StringLiteral<'a>) {}
+    fn exit_string_literal(&mut self, it: &mut StringLiteral<'src>) {}
 
     #[inline]
-    fn enter_variable_expression(&mut self, it: &mut VariableExpression<'a>) {}
+    fn enter_variable_expression(&mut self, it: &mut VariableExpression<'src>) {}
 
     #[inline]
-    fn exit_variable_expression(&mut self, it: &mut VariableExpression<'a>) {}
+    fn exit_variable_expression(&mut self, it: &mut VariableExpression<'src>) {}
 
     #[inline]
-    fn enter_variable_member(&mut self, it: &mut VariableMember<'a>) {}
+    fn enter_variable_member(&mut self, it: &mut VariableMember<'src>) {}
 
     #[inline]
-    fn exit_variable_member(&mut self, it: &mut VariableMember<'a>) {}
+    fn exit_variable_member(&mut self, it: &mut VariableMember<'src>) {}
 
     #[inline]
-    fn enter_parenthesized_expression(&mut self, it: &mut ParenthesizedExpression<'a>) {}
+    fn enter_parenthesized_expression(&mut self, it: &mut ParenthesizedExpression<'src>) {}
 
     #[inline]
-    fn exit_parenthesized_expression(&mut self, it: &mut ParenthesizedExpression<'a>) {}
+    fn exit_parenthesized_expression(&mut self, it: &mut ParenthesizedExpression<'src>) {}
 
     #[inline]
-    fn enter_block_expression(&mut self, it: &mut BlockExpression<'a>) {}
+    fn enter_block_expression(&mut self, it: &mut BlockExpression<'src>) {}
 
     #[inline]
-    fn exit_block_expression(&mut self, it: &mut BlockExpression<'a>) {}
+    fn exit_block_expression(&mut self, it: &mut BlockExpression<'src>) {}
 
     #[inline]
-    fn enter_binary_expression(&mut self, it: &mut BinaryExpression<'a>) {}
+    fn enter_binary_expression(&mut self, it: &mut BinaryExpression<'src>) {}
 
     #[inline]
-    fn exit_binary_expression(&mut self, it: &mut BinaryExpression<'a>) {}
+    fn exit_binary_expression(&mut self, it: &mut BinaryExpression<'src>) {}
 
     #[inline]
-    fn enter_unary_expression(&mut self, it: &mut UnaryExpression<'a>) {}
+    fn enter_unary_expression(&mut self, it: &mut UnaryExpression<'src>) {}
 
     #[inline]
-    fn exit_unary_expression(&mut self, it: &mut UnaryExpression<'a>) {}
+    fn exit_unary_expression(&mut self, it: &mut UnaryExpression<'src>) {}
 
     #[inline]
-    fn enter_update_expression(&mut self, it: &mut UpdateExpression<'a>) {}
+    fn enter_update_expression(&mut self, it: &mut UpdateExpression<'src>) {}
 
     #[inline]
-    fn exit_update_expression(&mut self, it: &mut UpdateExpression<'a>) {}
+    fn exit_update_expression(&mut self, it: &mut UpdateExpression<'src>) {}
 
     #[inline]
-    fn enter_ternary_expression(&mut self, it: &mut TernaryExpression<'a>) {}
+    fn enter_ternary_expression(&mut self, it: &mut TernaryExpression<'src>) {}
 
     #[inline]
-    fn exit_ternary_expression(&mut self, it: &mut TernaryExpression<'a>) {}
+    fn exit_ternary_expression(&mut self, it: &mut TernaryExpression<'src>) {}
 
     #[inline]
-    fn enter_conditional_expression(&mut self, it: &mut ConditionalExpression<'a>) {}
+    fn enter_conditional_expression(&mut self, it: &mut ConditionalExpression<'src>) {}
 
     #[inline]
-    fn exit_conditional_expression(&mut self, it: &mut ConditionalExpression<'a>) {}
+    fn exit_conditional_expression(&mut self, it: &mut ConditionalExpression<'src>) {}
 
     #[inline]
-    fn enter_resource_expression(&mut self, it: &mut ResourceExpression<'a>) {}
+    fn enter_resource_expression(&mut self, it: &mut ResourceExpression<'src>) {}
 
     #[inline]
-    fn exit_resource_expression(&mut self, it: &mut ResourceExpression<'a>) {}
+    fn exit_resource_expression(&mut self, it: &mut ResourceExpression<'src>) {}
 
     #[inline]
-    fn enter_array_access_expression(&mut self, it: &mut ArrayAccessExpression<'a>) {}
+    fn enter_array_access_expression(&mut self, it: &mut ArrayAccessExpression<'src>) {}
 
     #[inline]
-    fn exit_array_access_expression(&mut self, it: &mut ArrayAccessExpression<'a>) {}
+    fn exit_array_access_expression(&mut self, it: &mut ArrayAccessExpression<'src>) {}
 
     #[inline]
-    fn enter_arrow_access_expression(&mut self, it: &mut ArrowAccessExpression<'a>) {}
+    fn enter_arrow_access_expression(&mut self, it: &mut ArrowAccessExpression<'src>) {}
 
     #[inline]
-    fn exit_arrow_access_expression(&mut self, it: &mut ArrowAccessExpression<'a>) {}
+    fn exit_arrow_access_expression(&mut self, it: &mut ArrowAccessExpression<'src>) {}
 
     #[inline]
-    fn enter_call_expression(&mut self, it: &mut CallExpression<'a>) {}
+    fn enter_call_expression(&mut self, it: &mut CallExpression<'src>) {}
 
     #[inline]
-    fn exit_call_expression(&mut self, it: &mut CallExpression<'a>) {}
+    fn exit_call_expression(&mut self, it: &mut CallExpression<'src>) {}
 
     #[inline]
     fn enter_this_expression(&mut self, it: &mut ThisExpression) {}
@@ -182,7 +182,7 @@ pub trait Traverse<'a>: Sized {
     fn exit_this_expression(&mut self, it: &mut ThisExpression) {}
 }
 
-fn walk_program<'a>(traverser: &mut impl Traverse<'a>, it: &mut Program<'a>) {
+fn walk_program<'src>(traverser: &mut impl Traverse<'src>, it: &mut Program<'src>) {
     traverser.enter_program(it);
     match &mut it.body {
         ProgramBody::Simple(expr) => walk_expression(traverser, expr),
@@ -192,7 +192,7 @@ fn walk_program<'a>(traverser: &mut impl Traverse<'a>, it: &mut Program<'a>) {
     traverser.exit_program(it);
 }
 
-fn walk_statements<'a>(traverser: &mut impl Traverse<'a>, it: &mut Vec<Statement<'a>>) {
+fn walk_statements<'src>(traverser: &mut impl Traverse<'src>, it: &mut Vec<Statement<'src>>) {
     traverser.enter_statements(it);
     for stmt in it.iter_mut() {
         walk_statement(traverser, stmt);
@@ -200,7 +200,7 @@ fn walk_statements<'a>(traverser: &mut impl Traverse<'a>, it: &mut Vec<Statement
     traverser.exit_statements(it);
 }
 
-fn walk_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut Statement<'a>) {
+fn walk_statement<'src>(traverser: &mut impl Traverse<'src>, it: &mut Statement<'src>) {
     traverser.enter_statement(it);
     match it {
         Statement::Expression(it) => walk_expression(traverser, it),
@@ -215,9 +215,9 @@ fn walk_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut Statement<'a>)
     traverser.exit_statement(it);
 }
 
-fn walk_assignment_statement<'a>(
-    traverser: &mut impl Traverse<'a>,
-    it: &mut AssignmentStatement<'a>,
+fn walk_assignment_statement<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut AssignmentStatement<'src>,
 ) {
     traverser.enter_assignment_statement(it);
     walk_variable_expression(traverser, &mut it.left);
@@ -225,14 +225,17 @@ fn walk_assignment_statement<'a>(
     traverser.exit_assignment_statement(it);
 }
 
-fn walk_loop_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut LoopStatement<'a>) {
+fn walk_loop_statement<'src>(traverser: &mut impl Traverse<'src>, it: &mut LoopStatement<'src>) {
     traverser.enter_loop_statement(it);
     walk_expression(traverser, &mut it.count);
     walk_block_expression(traverser, &mut it.block);
     traverser.exit_loop_statement(it);
 }
 
-fn walk_for_each_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut ForEachStatement<'a>) {
+fn walk_for_each_statement<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut ForEachStatement<'src>,
+) {
     traverser.enter_for_each_statement(it);
     walk_variable_expression(traverser, &mut it.variable);
     walk_expression(traverser, &mut it.array);
@@ -240,28 +243,31 @@ fn walk_for_each_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut ForEa
     traverser.exit_for_each_statement(it);
 }
 
-fn walk_return_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut ReturnStatement<'a>) {
+fn walk_return_statement<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut ReturnStatement<'src>,
+) {
     traverser.enter_return_statement(it);
     walk_expression(traverser, &mut it.argument);
     traverser.exit_return_statement(it);
 }
 
-fn walk_break_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut BreakStatement) {
+fn walk_break_statement<'src>(traverser: &mut impl Traverse<'src>, it: &mut BreakStatement) {
     traverser.enter_break_statement(it);
     traverser.exit_break_statement(it);
 }
 
-fn walk_continue_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut ContinueStatement) {
+fn walk_continue_statement<'src>(traverser: &mut impl Traverse<'src>, it: &mut ContinueStatement) {
     traverser.enter_continue_statement(it);
     traverser.exit_continue_statement(it);
 }
 
-fn walk_empty_statement<'a>(traverser: &mut impl Traverse<'a>, it: &mut EmptyStatement) {
+fn walk_empty_statement<'src>(traverser: &mut impl Traverse<'src>, it: &mut EmptyStatement) {
     traverser.enter_empty_statement(it);
     traverser.exit_empty_statement(it);
 }
 
-fn walk_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut Expression<'a>) {
+fn walk_expression<'src>(traverser: &mut impl Traverse<'src>, it: &mut Expression<'src>) {
     traverser.enter_expression(it);
     match it {
         Expression::NumericLiteral(it) => walk_numeric_literal(traverser, it),
@@ -284,36 +290,36 @@ fn walk_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut Expression<'a
     traverser.exit_expression(it);
 }
 
-fn walk_identifier_reference<'a>(traverser: &mut impl Traverse<'a>, it: &mut Identifier<'a>) {
+fn walk_identifier_reference<'src>(traverser: &mut impl Traverse<'src>, it: &mut Identifier<'src>) {
     traverser.enter_identifier_reference(it);
     traverser.exit_identifier_reference(it);
 }
 
-fn walk_boolean_literal<'a>(traverser: &mut impl Traverse<'a>, it: &mut BooleanLiteral) {
+fn walk_boolean_literal<'src>(traverser: &mut impl Traverse<'src>, it: &mut BooleanLiteral) {
     traverser.enter_boolean_literal(it);
     traverser.exit_boolean_literal(it);
 }
 
-fn walk_numeric_literal<'a>(traverser: &mut impl Traverse<'a>, it: &mut NumericLiteral<'a>) {
+fn walk_numeric_literal<'src>(traverser: &mut impl Traverse<'src>, it: &mut NumericLiteral<'src>) {
     traverser.enter_numeric_literal(it);
     traverser.exit_numeric_literal(it);
 }
 
-fn walk_string_literal<'a>(traverser: &mut impl Traverse<'a>, it: &mut StringLiteral<'a>) {
+fn walk_string_literal<'src>(traverser: &mut impl Traverse<'src>, it: &mut StringLiteral<'src>) {
     traverser.enter_string_literal(it);
     traverser.exit_string_literal(it);
 }
 
-fn walk_variable_expression<'a>(
-    traverser: &mut impl Traverse<'a>,
-    it: &mut VariableExpression<'a>,
+fn walk_variable_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut VariableExpression<'src>,
 ) {
     traverser.enter_variable_expression(it);
     walk_variable_member(traverser, &mut it.member);
     traverser.exit_variable_expression(it);
 }
 
-fn walk_variable_member<'a>(traverser: &mut impl Traverse<'a>, it: &mut VariableMember<'a>) {
+fn walk_variable_member<'src>(traverser: &mut impl Traverse<'src>, it: &mut VariableMember<'src>) {
     traverser.enter_variable_member(it);
     match it {
         VariableMember::Object { object, property, .. } => {
@@ -327,9 +333,9 @@ fn walk_variable_member<'a>(traverser: &mut impl Traverse<'a>, it: &mut Variable
     traverser.exit_variable_member(it);
 }
 
-fn walk_parenthesized_expression<'a>(
-    traverser: &mut impl Traverse<'a>,
-    it: &mut ParenthesizedExpression<'a>,
+fn walk_parenthesized_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut ParenthesizedExpression<'src>,
 ) {
     traverser.enter_parenthesized_expression(it);
     match &mut it.body {
@@ -343,32 +349,47 @@ fn walk_parenthesized_expression<'a>(
     traverser.exit_parenthesized_expression(it);
 }
 
-fn walk_block_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut BlockExpression<'a>) {
+fn walk_block_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut BlockExpression<'src>,
+) {
     traverser.enter_block_expression(it);
     walk_statements(traverser, &mut it.statements);
     traverser.exit_block_expression(it);
 }
 
-fn walk_binary_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut BinaryExpression<'a>) {
+fn walk_binary_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut BinaryExpression<'src>,
+) {
     traverser.enter_binary_expression(it);
     walk_expression(traverser, &mut it.left);
     walk_expression(traverser, &mut it.right);
     traverser.exit_binary_expression(it);
 }
 
-fn walk_unary_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut UnaryExpression<'a>) {
+fn walk_unary_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut UnaryExpression<'src>,
+) {
     traverser.enter_unary_expression(it);
     walk_expression(traverser, &mut it.argument);
     traverser.exit_unary_expression(it);
 }
 
-fn walk_update_expression<'a>(visitor: &mut impl Traverse<'a>, it: &mut UpdateExpression<'a>) {
+fn walk_update_expression<'src>(
+    visitor: &mut impl Traverse<'src>,
+    it: &mut UpdateExpression<'src>,
+) {
     visitor.enter_update_expression(it);
     walk_variable_expression(visitor, &mut it.variable);
     visitor.exit_update_expression(it);
 }
 
-fn walk_ternary_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut TernaryExpression<'a>) {
+fn walk_ternary_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut TernaryExpression<'src>,
+) {
     traverser.enter_ternary_expression(it);
     walk_expression(traverser, &mut it.test);
     walk_expression(traverser, &mut it.consequent);
@@ -376,9 +397,9 @@ fn walk_ternary_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut Terna
     traverser.exit_ternary_expression(it);
 }
 
-fn walk_conditional_expression<'a>(
-    traverser: &mut impl Traverse<'a>,
-    it: &mut ConditionalExpression<'a>,
+fn walk_conditional_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut ConditionalExpression<'src>,
 ) {
     traverser.enter_conditional_expression(it);
     walk_expression(traverser, &mut it.test);
@@ -386,18 +407,18 @@ fn walk_conditional_expression<'a>(
     traverser.exit_conditional_expression(it);
 }
 
-fn walk_resource_expression<'a>(
-    traverser: &mut impl Traverse<'a>,
-    it: &mut ResourceExpression<'a>,
+fn walk_resource_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut ResourceExpression<'src>,
 ) {
     traverser.enter_resource_expression(it);
     walk_identifier_reference(traverser, &mut it.name);
     traverser.exit_resource_expression(it);
 }
 
-fn walk_array_access_expression<'a>(
-    traverser: &mut impl Traverse<'a>,
-    it: &mut ArrayAccessExpression<'a>,
+fn walk_array_access_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut ArrayAccessExpression<'src>,
 ) {
     traverser.enter_array_access_expression(it);
     walk_identifier_reference(traverser, &mut it.name);
@@ -405,9 +426,9 @@ fn walk_array_access_expression<'a>(
     traverser.exit_array_access_expression(it);
 }
 
-fn walk_arrow_access_expression<'a>(
-    traverser: &mut impl Traverse<'a>,
-    it: &mut ArrowAccessExpression<'a>,
+fn walk_arrow_access_expression<'src>(
+    traverser: &mut impl Traverse<'src>,
+    it: &mut ArrowAccessExpression<'src>,
 ) {
     traverser.enter_arrow_access_expression(it);
     walk_expression(traverser, &mut it.left);
@@ -415,7 +436,7 @@ fn walk_arrow_access_expression<'a>(
     traverser.exit_arrow_access_expression(it);
 }
 
-fn walk_call_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut CallExpression<'a>) {
+fn walk_call_expression<'src>(traverser: &mut impl Traverse<'src>, it: &mut CallExpression<'src>) {
     traverser.enter_call_expression(it);
     walk_identifier_reference(traverser, &mut it.callee);
     if let Some(args) = &mut it.arguments {
@@ -426,7 +447,7 @@ fn walk_call_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut CallExpr
     traverser.exit_call_expression(it);
 }
 
-fn walk_this_expression<'a>(traverser: &mut impl Traverse<'a>, it: &mut ThisExpression) {
+fn walk_this_expression<'src>(traverser: &mut impl Traverse<'src>, it: &mut ThisExpression) {
     traverser.enter_this_expression(it);
     traverser.exit_this_expression(it);
 }


### PR DESCRIPTION
Working on #12 will involve dealing with multiple lifetimes. Renaming the AST's lifetimes (which is the source code string's) will help make it clearer.