### PR TITLE
refactor(parser): remove `panicked` field from `ParseResult`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,13 @@ use nolana::{semantic::SemanticChecker, Codegen, CodegenOptions, ParseResult, Pa
 let source_text = "math.cos(q.anim_time * 38) * v.rotation_scale + v.x * v.x * q.life_time";
 
 // Parse the provided Molang source code.
-let ParseResult {
-    program,
-    errors,
-    panicked,
-} = Parser::new(source_text).parse();
+let ParseResult { program, errors } = Parser::new(source_text).parse();
 
 // Check for syntax errors.
 if !errors.is_empty() {
     for error in errors {
         let error = error.with_source_code(source_text);
         print!("{error:?}");
-    }
-    if panicked {
-        println!("Encountered an unrecoverable error");
     }
     return;
 }

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -9,15 +9,12 @@ use nolana::{
 fn main() {
     let source_text = fs::read_to_string("examples/sample.molang").unwrap();
 
-    let ParseResult { mut program, errors, panicked } = Parser::new(&source_text).parse();
+    let ParseResult { mut program, errors } = Parser::new(&source_text).parse();
 
     if !errors.is_empty() {
         for error in errors {
             let error = error.with_source_code(source_text.clone());
             print!("{error:?}");
-        }
-        if panicked {
-            println!("Encountered an unrecoverable error");
         }
         return;
     }

--- a/examples/parser.rs
+++ b/examples/parser.rs
@@ -5,15 +5,12 @@ use nolana::{ParseResult, Parser};
 fn main() {
     let source_text = fs::read_to_string("examples/sample.molang").unwrap();
 
-    let ParseResult { program, errors, panicked } = Parser::new(&source_text).parse();
+    let ParseResult { program, errors } = Parser::new(&source_text).parse();
 
     if !errors.is_empty() {
         for error in errors {
             let error = error.with_source_code(source_text.clone());
             print!("{error:?}");
-        }
-        if panicked {
-            println!("Encountered an unrecoverable error");
         }
         return;
     }

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -32,15 +32,12 @@ impl<'a> Traverse<'a> for MolangStats {
 fn main() {
     let source_text = fs::read_to_string("examples/sample.molang").unwrap();
 
-    let ParseResult { mut program, errors, panicked } = Parser::new(&source_text).parse();
+    let ParseResult { mut program, errors } = Parser::new(&source_text).parse();
 
     if !errors.is_empty() {
         for error in errors {
             let error = error.with_source_code(source_text.clone());
             print!("{error:?}");
-        }
-        if panicked {
-            println!("The encountered errors were unrecoverable");
         }
         return;
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,7 +26,6 @@ use crate::{
 ///
 /// [`program`]: ParseResult::program
 /// [`errors`]: ParseResult::errors
-/// [`panicked`]: ParseResult::panicked
 #[derive(Debug)]
 pub struct ParseResult<'src> {
     pub program: Program<'src>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -23,7 +23,6 @@ use crate::{
 /// anyway. When this happens:
 /// 1. [`program`] will contain an AST
 /// 2. [`errors`] will be non-empty
-/// 3. [`panicked`] will be false
 ///
 /// [`program`]: ParseResult::program
 /// [`errors`]: ParseResult::errors
@@ -32,7 +31,6 @@ use crate::{
 pub struct ParseResult<'src> {
     pub program: Program<'src>,
     pub errors: Vec<Diagnostic>,
-    pub panicked: bool,
 }
 
 /// Recursive Descent Parser for [Molang](https://bedrock.dev/docs/stable/Molang).
@@ -63,19 +61,18 @@ impl<'src> Parser<'src> {
     /// See [`ParseResult`] for more info.
     pub fn parse(mut self) -> ParseResult<'src> {
         self.bump(); // First token.
-        let (program, panicked) = match self.parse_program() {
-            Ok(program) => (program, false),
+        let program = match self.parse_program() {
+            Ok(program) => program,
             Err(error) => {
                 self.error(error);
-                let program = Program {
+                Program {
                     span: Span::default(),
                     source: self.source_code,
                     body: ProgramBody::Empty,
-                };
-                (program, true)
+                }
             }
         };
-        ParseResult { program, errors: self.errors, panicked }
+        ParseResult { program, errors: self.errors }
     }
 
     fn parse_program(&mut self) -> Result<Program<'src>> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -20,7 +20,6 @@ fn read_and_codegen(path: &Path) -> String {
     let source = fs::read_to_string(path).unwrap();
     let result = Parser::new(&source).parse();
     assert!(result.errors.is_empty());
-    assert!(!result.panicked);
     Codegen::default().build(&result.program)
 }
 

--- a/tests/snapshots/parser@array_access.nolana.snap
+++ b/tests/snapshots/parser@array_access.nolana.snap
@@ -45,5 +45,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@arrow_access.nolana.snap
+++ b/tests/snapshots/parser@arrow_access.nolana.snap
@@ -57,5 +57,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@assignment.nolana.snap
+++ b/tests/snapshots/parser@assignment.nolana.snap
@@ -531,5 +531,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@binary.nolana.snap
+++ b/tests/snapshots/parser@binary.nolana.snap
@@ -389,5 +389,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@block.nolana.snap
+++ b/tests/snapshots/parser@block.nolana.snap
@@ -39,5 +39,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@block_undelimited.nolana.snap
+++ b/tests/snapshots/parser@block_undelimited.nolana.snap
@@ -63,5 +63,4 @@ ParseResult {
             },
         },
     ],
-    panicked: false,
 }

--- a/tests/snapshots/parser@boolean.nolana.snap
+++ b/tests/snapshots/parser@boolean.nolana.snap
@@ -37,5 +37,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@call_unclosed.nolana.snap
+++ b/tests/snapshots/parser@call_unclosed.nolana.snap
@@ -36,5 +36,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@complex.nolana.snap
+++ b/tests/snapshots/parser@complex.nolana.snap
@@ -51,5 +51,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@conditional.nolana.snap
+++ b/tests/snapshots/parser@conditional.nolana.snap
@@ -124,5 +124,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@for_each.nolana.snap
+++ b/tests/snapshots/parser@for_each.nolana.snap
@@ -126,5 +126,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@for_each_in_expr.nolana.snap
+++ b/tests/snapshots/parser@for_each_in_expr.nolana.snap
@@ -36,5 +36,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@for_each_invalid_first_arg.nolana.snap
+++ b/tests/snapshots/parser@for_each_invalid_first_arg.nolana.snap
@@ -34,5 +34,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@keywords.nolana.snap
+++ b/tests/snapshots/parser@keywords.nolana.snap
@@ -59,5 +59,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@loop.nolana.snap
+++ b/tests/snapshots/parser@loop.nolana.snap
@@ -103,5 +103,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@loop_in_block.nolana.snap
+++ b/tests/snapshots/parser@loop_in_block.nolana.snap
@@ -150,5 +150,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@loop_with_expr.nolana.snap
+++ b/tests/snapshots/parser@loop_with_expr.nolana.snap
@@ -36,5 +36,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@missing_semi_with_assignment.nolana.snap
+++ b/tests/snapshots/parser@missing_semi_with_assignment.nolana.snap
@@ -94,5 +94,4 @@ ParseResult {
             },
         },
     ],
-    panicked: false,
 }

--- a/tests/snapshots/parser@missing_semi_with_semi.nolana.snap
+++ b/tests/snapshots/parser@missing_semi_with_semi.nolana.snap
@@ -63,5 +63,4 @@ ParseResult {
             },
         },
     ],
-    panicked: false,
 }

--- a/tests/snapshots/parser@parenthesized_complex.nolana.snap
+++ b/tests/snapshots/parser@parenthesized_complex.nolana.snap
@@ -99,5 +99,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@parenthesized_nested.nolana.snap
+++ b/tests/snapshots/parser@parenthesized_nested.nolana.snap
@@ -63,5 +63,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@parenthesized_simple.nolana.snap
+++ b/tests/snapshots/parser@parenthesized_simple.nolana.snap
@@ -34,5 +34,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@parenthesized_unclosed.nolana.snap
+++ b/tests/snapshots/parser@parenthesized_unclosed.nolana.snap
@@ -36,5 +36,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@resource.nolana.snap
+++ b/tests/snapshots/parser@resource.nolana.snap
@@ -69,5 +69,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@semisemisemisemi.nolana.snap
+++ b/tests/snapshots/parser@semisemisemisemi.nolana.snap
@@ -735,5 +735,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@string.nolana.snap
+++ b/tests/snapshots/parser@string.nolana.snap
@@ -22,5 +22,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@ternary.nolana.snap
+++ b/tests/snapshots/parser@ternary.nolana.snap
@@ -219,5 +219,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@unary.nolana.snap
+++ b/tests/snapshots/parser@unary.nolana.snap
@@ -115,5 +115,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@unterminated_string.nolana.snap
+++ b/tests/snapshots/parser@unterminated_string.nolana.snap
@@ -34,5 +34,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@update.nolana.snap
+++ b/tests/snapshots/parser@update.nolana.snap
@@ -136,5 +136,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@update_with_context.nolana.snap
+++ b/tests/snapshots/parser@update_with_context.nolana.snap
@@ -34,5 +34,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@update_with_query.nolana.snap
+++ b/tests/snapshots/parser@update_with_query.nolana.snap
@@ -34,5 +34,4 @@ ParseResult {
             },
         },
     ],
-    panicked: true,
 }

--- a/tests/snapshots/parser@variable.nolana.snap
+++ b/tests/snapshots/parser@variable.nolana.snap
@@ -135,5 +135,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }

--- a/tests/snapshots/parser@variable_member_keyword.nolana.snap
+++ b/tests/snapshots/parser@variable_member_keyword.nolana.snap
@@ -121,5 +121,4 @@ ParseResult {
         ),
     },
     errors: [],
-    panicked: false,
 }


### PR DESCRIPTION
Addresses #40. `ParseResult.panicked` is set to `true` when at least one error has occurred, which isn't entirely accurate. But since Nolana has no notion of "non-recoverable errors", having this field provides nothing of value to the user as `ParseResults.errors` already includes the encountered errors.